### PR TITLE
Add the possibility to register DOMPurify hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,23 @@ The `default` [DOMPurify configuration](https://github.com/cure53/DOMPurify#can-
     <div v-dompurify-html="rawHtml"></div>
 </div>
 ```
+
+There is also the possibility to set-up [DOMPurify hooks](https://github.com/cure53/DOMPurify#hooks):
+```js
+import { createApp } from 'vue'
+import VueDOMPurifyHTML from 'vue-dompurify-html'
+
+const app = createApp({
+    data: () => ({
+        rawHtml: '<span style="color: red">This should be red.</span>'
+    })
+});
+app.use(VueDOMPurifyHTML, {
+  hooks: {
+    uponSanitizeElement: (currentNode) => {
+      // Do something with the node
+    }   
+  }
+});
+app.mount('#app');
+```

--- a/test/vue-dompurify-html.spec.ts
+++ b/test/vue-dompurify-html.spec.ts
@@ -279,4 +279,32 @@ describe('VueDOMPurifyHTML Test Suite', (): void => {
             '<div>\n' + '  <!---->\n' + '  <!---->\n' + '</div>'
         );
     });
+
+    it('can use DOMPurify hooks', async (): Promise<void> => {
+        const component = {
+            template: '<p v-dompurify-html="rawHtml"></p>',
+            props: ['rawHtml'],
+        };
+
+        const uponSanitizeElement = jest.fn();
+        const afterSanitizeElements = jest.fn();
+
+        const localVue = createLocalVue();
+        localVue.use(VueDOMPurifyHTML, {
+            hooks: {
+                uponSanitizeElement,
+                afterSanitizeElements,
+            },
+        });
+
+        shallowMount(component, {
+            propsData: {
+                rawHtml: '<p>Some element</p>',
+            },
+            localVue,
+        });
+
+        expect(uponSanitizeElement).toHaveBeenCalled();
+        expect(afterSanitizeElements).toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
⚠️ As the directive uses the global DOMPurify instance, adding a hook can have an impact outside of the directive.

Closes #367.