### PR TITLE
Render contents on server side with Nuxt

### DIFF
--- a/dist/dompurify-html.js
+++ b/dist/dompurify-html.js
@@ -20,10 +20,12 @@ function buildDirective(config) {
         var namedConfigurations = config.namedConfigurations;
         if (namedConfigurations &&
             typeof namedConfigurations[arg] !== 'undefined') {
-            el.innerHTML = dompurify_1.sanitize(binding.value, namedConfigurations[arg]);
+            el.innerHTML =
+                el.innerHTML ||
+                    dompurify_1.sanitize(binding.value, namedConfigurations[arg]);
             return;
         }
-        el.innerHTML = dompurify_1.sanitize(binding.value, config.default);
+        el.innerHTML = el.innerHTML || dompurify_1.sanitize(binding.value, config.default);
     };
     return {
         inserted: updateComponent,

--- a/src/dompurify-html.ts
+++ b/src/dompurify-html.ts
@@ -77,10 +77,12 @@ export function buildDirective(config: DirectiveConfig = {}): DirectiveOptions {
             namedConfigurations &&
             typeof namedConfigurations[arg] !== 'undefined'
         ) {
-            el.innerHTML = sanitize(binding.value, namedConfigurations[arg]);
+            el.innerHTML =
+                el.innerHTML ||
+                sanitize(binding.value, namedConfigurations[arg]);
             return;
         }
-        el.innerHTML = sanitize(binding.value, config.default);
+        el.innerHTML = el.innerHTML || sanitize(binding.value, config.default);
     };
 
     return {


### PR DESCRIPTION
My problem is related for #360  
If we use property of render in Nuxt, can fill contents on server-side. example:

```js
// nuxt.config.js
export default {
  render: {
    bundleRenderer: {
      directives: {
        dompurifyHtml(vnode, dir) {
          vnode.data.domProps = {
            innerHTML: dir.value
          }
        }
      }
    }
  }
}
```

Specifying this option allows you to change the element's innerHTML using a directive, but innerHTML is replaced with client-side behavior. So if innerHTML is already populated on server side, you should ignore it on client side. 