### PR TITLE
Make possible to use vue-dompurify-html as a local directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,18 @@ app.use(VueDOMPurifyHTML, {
 });
 app.mount('#app');
 ```
+
+If needed you can use the directive without installing it globally:
+
+```ts
+<template>
+    <div v-dompurify-html="rawHtml"></div>
+</template>
+
+<script setup lang="ts">
+import { buildVueDompurifyHTMLDirective } from '../src/';
+
+const vdompurifyHtml = buildVueDompurifyHTMLDirective(<config...>);
+const rawHtml = '<span style="color: red">Hello!</span>';
+</script>
+```

--- a/example/Example.vue
+++ b/example/Example.vue
@@ -1,8 +1,13 @@
 <template>
+    <h1>Global directive</h1>
     <div v-dompurify-html="rawHtml">Expect text with color</div>
     <div v-dompurify-html:plaintext="rawHtml">Expect only plaintext</div>
+    <h1>Directive local to a component</h1>
+    <example-local-directive />
 </template>
 
 <script setup lang="ts">
+import ExampleLocalDirective from "./ExampleLocalDirective.vue";
+
 const rawHtml = '<span style="color: red">Hello!</span><img src=a onerror="alert(1)">';
 </script>

--- a/example/ExampleLocalDirective.vue
+++ b/example/ExampleLocalDirective.vue
@@ -1,0 +1,10 @@
+<template>
+    <div v-clean-html="rawHtml">Expect text with color</div>
+</template>
+
+<script setup lang="ts">
+import { buildVueDompurifyHTMLDirective } from '../src/';
+
+const vCleanHtml = buildVueDompurifyHTMLDirective();
+const rawHtml = '<span style="color: red">Hello!</span><img src=a onerror="alert(1)">';
+</script>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { App } from 'vue';
+import { App, Plugin } from 'vue';
 import {
     buildDirective,
     DirectiveConfig,
@@ -6,8 +6,10 @@ import {
 } from './dompurify-html';
 export type { DirectiveConfig, MinimalDOMPurifyConfig };
 
-export default {
+export const vueDompurifyHTMLPlugin: Plugin = {
     install(app: App, config: DirectiveConfig = {}): void {
         app.directive('dompurify-html', buildDirective(config));
     },
 };
+export { buildDirective as buildVueDompurifyHTMLDirective } from './dompurify-html';
+export default vueDompurifyHTMLPlugin;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,5 +1,6 @@
 import { createApp } from 'vue';
 import VueDOMPurifyHTML from '../src';
+import { buildVueDompurifyHTMLDirective } from '../src';
 
 describe('VueDOMPurifyHTML Plugin Install', (): void => {
     it('can be installed', (): void => {
@@ -40,5 +41,24 @@ describe('VueDOMPurifyHTML Plugin Install', (): void => {
         app.mount(el);
 
         expect(el.innerHTML).toBe('<p>Hello</p>');
+    });
+
+    it('can be used locally inside a component', () => {
+        const el = document.createElement('div');
+
+        const component = {
+            directives: {
+                foo: buildVueDompurifyHTMLDirective(),
+            },
+            setup(): { rawHtml: string } {
+                return { rawHtml: '<b>Hello<script></script></b>' };
+            },
+            template: '<p v-foo="rawHtml"></p>',
+        };
+
+        const app = createApp(component);
+        app.mount(el);
+
+        expect(el.innerHTML).toBe('<p><b>Hello</b></p>');
     });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
                 globals: {
                     dompurify: 'DOMPurify',
                 },
+                exports: 'named',
             },
         },
     },


### PR DESCRIPTION
Until now, the directive could only be loaded globally. This contribution exposes the necessary interface so it can be used locally inside a component.