### PR TITLE
Don't sanitize again when the binding value is unchanged

### DIFF
--- a/src/dompurify-html.ts
+++ b/src/dompurify-html.ts
@@ -85,6 +85,9 @@ export function buildDirective(config: DirectiveConfig = {}): DirectiveOptions {
         el: HTMLElement,
         binding: VNodeDirective
     ): void {
+        if (binding.oldValue === binding.value) {
+            return;
+        }
         const arg = binding.arg;
         const namedConfigurations = config.namedConfigurations;
         if (


### PR DESCRIPTION
Hello,

This PR modifies the purification process by skipping the sanitization when the binded value is unchanged.
In this way it won't trigger any redundant `DOMPurify.sanitize` calls.

The PR can be merged also in `vue-next` branch for Vue 3 support.

Thanks,
Otto