### PR TITLE
Don't sanitize again when the value is the same [vue-next]

### DIFF
--- a/src/dompurify-html.ts
+++ b/src/dompurify-html.ts
@@ -103,6 +103,9 @@ export function buildDirective(
         el: HTMLElement,
         binding: DirectiveBinding
     ): void {
+        if (binding.oldValue === binding.value) {
+            return;
+        }
         const arg = binding.arg;
         const namedConfigurations = config.namedConfigurations;
         const defaultConfig = config.default ?? {};

--- a/test/vue-dompurify-html.spec.ts
+++ b/test/vue-dompurify-html.spec.ts
@@ -344,4 +344,31 @@ describe('VueDOMPurifyHTML Test Suite', (): void => {
         expect(afterSanitizeElements).toHaveBeenCalled();
         expect(addHookSpy).toBeCalledTimes(2);
     });
+
+    it('does not rerender when input not changed', async (): Promise<void> => {
+        const component = {
+            template: '<p v-dompurify-html="rawHtml"></p>',
+            props: ['rawHtml'],
+        };
+
+        const wrapper = mount(component, {
+            global: {
+                directives: {
+                    'dompurify-html': buildDirective(),
+                },
+            },
+            props: {
+                rawHtml: '<pre>Hello</pre>',
+                otherProp: 'original',
+            },
+        });
+
+        wrapper.setProps({
+            otherProp: 'changed',
+        });
+
+        await wrapper.vm.$nextTick();
+
+        expect(sanitizeSpy).toBeCalledTimes(1);
+    });
 });


### PR DESCRIPTION
Hello,

This PR modifies the purification process by skipping the sanitization when the binded value is unchanged.
In this way it won't trigger any redundant `DOMPurify.sanitize` calls.

This PR is for the `vue-next` branch. See ref #1812 for the main (Vue 2) branch.

Thanks,
Otto