### PR TITLE
Allow to specify a custom DOMPurify instance builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ app.mount('#app');
 
 ## Usage with [Nuxt](https://nuxtjs.org/)
 
+### Client side
+
 The usage is similar than when directly using Vue.
 
 Define a new Nuxt plugin to import and setup the directive to your liking:
@@ -142,3 +144,40 @@ export default {
   plugins: [{ src: '~/plugins/dompurify', mode: 'client' }]
 }
 ```
+
+### Server side
+
+The usage is similar than when directly using Vue but you need to setup DOMPurify to work with Node.
+
+Install this package, DOMPurify and [JSDOM](https://github.com/jsdom/jsdom):
+
+```
+npm install vue-dompurify-html@vue-legacy dompurify jsdom
+```
+
+In your Nuxt config you will need to setup a "server-side" directive:
+
+```js
+export default {
+    render: {
+        bundleRenderer: {
+            directives: {
+                'dompurify-html': (el, dir) => {
+                    const insertHook = buildVueDompurifyHTMLDirective(
+                        {},
+                        () => {
+                            const window = new JSDOM('').window;
+                            return createDOMPurify(window);
+                        }
+                    ).inserted;
+                    insertHook(el, dir);
+                    el.data.domProps = { innerHTML: el.innerHTML };
+                }
+            }
+        }
+    }
+}
+```
+
+Note that if you are not using [`injectScripts: false`](https://nuxtjs.org/docs/configuration-glossary/configuration-render/#injectscripts)
+in your Nuxt config you will also need to register a client-side plugin as described just before.

--- a/dist/dompurify-html.d.ts
+++ b/dist/dompurify-html.d.ts
@@ -1,5 +1,7 @@
 import { DirectiveOptions } from 'vue';
-import { HookEvent, HookName, SanitizeAttributeHookEvent, SanitizeElementHookEvent } from 'dompurify';
+import { DOMPurifyI, HookEvent, HookName, SanitizeAttributeHookEvent, SanitizeElementHookEvent } from 'dompurify';
+declare type MinimalDOMPurifyInstance = Pick<DOMPurifyI, 'sanitize' | 'addHook'>;
+export declare type DOMPurifyInstanceBuilder = () => MinimalDOMPurifyInstance;
 export interface MinimalDOMPurifyConfig {
     ADD_ATTR?: string[] | undefined;
     ADD_DATA_URI_TAGS?: string[] | undefined;
@@ -34,4 +36,6 @@ export interface DirectiveConfig {
         [H in HookName]?: (currentNode: Element, data: HookEvent, config: MinimalDOMPurifyConfig) => void;
     };
 }
-export declare function buildDirective(config?: DirectiveConfig): DirectiveOptions;
+export declare function defaultDOMPurifyInstanceBuilder(): DOMPurifyI;
+export declare function buildDirective(config?: DirectiveConfig, buildDOMPurifyInstance?: DOMPurifyInstanceBuilder): DirectiveOptions;
+export {};

--- a/dist/dompurify-html.js
+++ b/dist/dompurify-html.js
@@ -3,23 +3,31 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.buildDirective = void 0;
+exports.buildDirective = exports.defaultDOMPurifyInstanceBuilder = void 0;
 var dompurify_1 = __importDefault(require("dompurify"));
-function setUpHooks(config) {
+function defaultDOMPurifyInstanceBuilder() {
+    return dompurify_1.default;
+}
+exports.defaultDOMPurifyInstanceBuilder = defaultDOMPurifyInstanceBuilder;
+function setUpHooks(config, dompurifyInstance) {
     var _a;
     var hooks = (_a = config.hooks) !== null && _a !== void 0 ? _a : {};
     var hookName;
     for (hookName in hooks) {
         var hook = hooks[hookName];
         if (hook !== undefined) {
-            dompurify_1.default.addHook(hookName, hook);
+            dompurifyInstance.addHook(hookName, hook);
         }
     }
 }
-function buildDirective(config) {
+function buildDirective(config, buildDOMPurifyInstance) {
     if (config === void 0) { config = {}; }
-    setUpHooks(config);
+    if (buildDOMPurifyInstance === void 0) { buildDOMPurifyInstance = defaultDOMPurifyInstanceBuilder; }
+    var dompurifyInstance = buildDOMPurifyInstance();
+    setUpHooks(config, dompurifyInstance);
     var updateComponent = function (el, binding) {
+        console.log("in directive")
+        console.log(el)
         var _a;
         if (binding.oldValue === binding.value) {
             return;
@@ -29,10 +37,11 @@ function buildDirective(config) {
         if (namedConfigurations &&
             arg !== undefined &&
             typeof namedConfigurations[arg] !== 'undefined') {
-            el.innerHTML = dompurify_1.default.sanitize(binding.value, namedConfigurations[arg]);
+            el.innerHTML = dompurifyInstance.sanitize(binding.value, namedConfigurations[arg]);
             return;
         }
-        el.innerHTML = dompurify_1.default.sanitize(binding.value, (_a = config.default) !== null && _a !== void 0 ? _a : {});
+        el.innerHTML = dompurifyInstance.sanitize(binding.value, (_a = config.default) !== null && _a !== void 0 ? _a : {});
+        console.log(el.innerHTML)
     };
     return {
         inserted: updateComponent,

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,7 +1,8 @@
 import { VueConstructor } from 'vue';
-import { DirectiveConfig, MinimalDOMPurifyConfig } from './dompurify-html';
-export { DirectiveConfig, MinimalDOMPurifyConfig };
+import { defaultDOMPurifyInstanceBuilder, DirectiveConfig, MinimalDOMPurifyConfig, DOMPurifyInstanceBuilder } from './dompurify-html';
+export { DirectiveConfig, MinimalDOMPurifyConfig, DOMPurifyInstanceBuilder };
+export { buildDirective as buildVueDompurifyHTMLDirective } from './dompurify-html';
 declare const _default: {
-    install(Vue: VueConstructor, config?: DirectiveConfig): void;
+    install(Vue: VueConstructor, config?: DirectiveConfig, buildDOMPurifyInstance?: typeof defaultDOMPurifyInstanceBuilder): void;
 };
 export default _default;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,9 +1,13 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.buildVueDompurifyHTMLDirective = void 0;
 var dompurify_html_1 = require("./dompurify-html");
+var dompurify_html_2 = require("./dompurify-html");
+Object.defineProperty(exports, "buildVueDompurifyHTMLDirective", { enumerable: true, get: function () { return dompurify_html_2.buildDirective; } });
 exports.default = {
-    install: function (Vue, config) {
+    install: function (Vue, config, buildDOMPurifyInstance) {
         if (config === void 0) { config = {}; }
-        Vue.directive('dompurify-html', (0, dompurify_html_1.buildDirective)(config));
+        if (buildDOMPurifyInstance === void 0) { buildDOMPurifyInstance = dompurify_html_1.defaultDOMPurifyInstanceBuilder; }
+        Vue.directive('dompurify-html', (0, dompurify_html_1.buildDirective)(config, buildDOMPurifyInstance));
     },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,24 @@
 import { VueConstructor } from 'vue';
 import {
     buildDirective,
+    defaultDOMPurifyInstanceBuilder,
     DirectiveConfig,
     MinimalDOMPurifyConfig,
+    DOMPurifyInstanceBuilder,
 } from './dompurify-html';
-export { DirectiveConfig, MinimalDOMPurifyConfig };
+export { DirectiveConfig, MinimalDOMPurifyConfig, DOMPurifyInstanceBuilder };
+
+export { buildDirective as buildVueDompurifyHTMLDirective } from './dompurify-html';
 
 export default {
-    install(Vue: VueConstructor, config: DirectiveConfig = {}): void {
-        Vue.directive('dompurify-html', buildDirective(config));
+    install(
+        Vue: VueConstructor,
+        config: DirectiveConfig = {},
+        buildDOMPurifyInstance = defaultDOMPurifyInstanceBuilder
+    ): void {
+        Vue.directive(
+            'dompurify-html',
+            buildDirective(config, buildDOMPurifyInstance)
+        );
     },
 };


### PR DESCRIPTION
This make possible for server-side users (e.g. Nuxt) to instantiate DOMPurify with JSDOM.

The README has been update to describe the setup.

See #1917.