### PR TITLE
fix: export type definition explicitly

### DIFF
--- a/packages/vue-dompurify-html/package.json
+++ b/packages/vue-dompurify-html/package.json
@@ -14,7 +14,8 @@
   "exports": {
     ".": {
       "import": "./dist/vue-dompurify-html.mjs",
-      "require": "./dist/vue-dompurify-html.umd.js"
+      "require": "./dist/vue-dompurify-html.umd.js",
+      "types": "./types/index.d.ts"
     }
   },
   "repository": {


### PR DESCRIPTION
From TypeScript 5.0, `--moduleResolution bundler` option has been introduced.
To support this option, this library must satisfy `exports` condition: contain `import` and `types`.
Since this library does not defined `types` in `exports`, the following error is shown building with the option enabled. 

```
> vue-tsc --noEmit && vite build

src/main.ts:11:30 - error TS7016: Could not find a declaration file for module 'vue-dompurify-html'. '/workspace/node_modules/.pnpm/vue-dompurify-html@4.0.0_vue@3.2.47/node_modules/vue-dompurify-html/dist/vue-dompurify-html.mjs' implicitly has an 'any' type.
  There are types at '/workspace/frontend/node_modules/vue-dompurify-html/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'vue-dompurify-html' library may need to update its package.json or typings.

11 import VueDOMPurifyHTML from 'vue-dompurify-html'
                                ~~~~~~~~~~~~~~~~~~~~


Found 1 error in src/main.ts:11

 ELIFECYCLE  Command failed with exit code 2.
```

More info of `--moduleResolution bundler`: https://github.com/microsoft/TypeScript/pull/51669