### PR TITLE
chore: Add web-types.json for WebStorm

### DIFF
--- a/packages/vue-dompurify-html/package.json
+++ b/packages/vue-dompurify-html/package.json
@@ -7,9 +7,11 @@
     "main": "./dist/vue-dompurify-html.umd.js",
     "module": "./dist/vue-dompurify-html.mjs",
     "types": "types/index.d.ts",
+    "web-types": "./web-types.json",
     "files": [
         "/dist",
-        "/types"
+        "/types",
+        "web-types.json"
     ],
     "exports": {
         ".": {

--- a/packages/vue-dompurify-html/web-types.json
+++ b/packages/vue-dompurify-html/web-types.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json.schemastore.org/web-types",
+    "name": "vue-dompurify-html",
+    "framework": "vue",
+    "js-types-syntax": "typescript",
+    "framework-config": {
+        "enable-when": {
+            "file-extensions": ["vue"]
+        }
+    },
+    "contributions": {
+        "html": {
+            "vue-directives": [
+                {
+                    "name": "dompurify-html",
+                    "description": "Safe replacement for the v-html directive",
+                    "doc-url": "https://github.com/LeSuisse/vue-dompurify-html/tree/main/packages/vue-dompurify-html"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Add web-types.json for IDE editors such as WebStorm