### PR TITLE
chore(deps): upgrade dompurify to v3.2.1

### DIFF
--- a/packages/vue-dompurify-html/package.json
+++ b/packages/vue-dompurify-html/package.json
@@ -45,7 +45,7 @@
         "test-mutation": "stryker run"
     },
     "dependencies": {
-        "dompurify": "^3.0.0"
+        "dompurify": "^3.2.1"
     },
     "peerDependencies": {
         "vue": "^3.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
   packages/vue-dompurify-html:
     dependencies:
       dompurify:
-        specifier: ^3.0.0
-        version: 3.1.3
+        specifier: ^3.2.1
+        version: 3.2.1
     devDependencies:
       '@stryker-mutator/core':
         specifier: 8.6.0
@@ -1281,6 +1281,9 @@ packages:
   '@types/trusted-types@2.0.2':
     resolution: {integrity: sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/wrap-ansi@3.0.0':
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
 
@@ -2150,8 +2153,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.1.3:
-    resolution: {integrity: sha512-5sOWYSNPaxz6o2MUPvtyxTTqR4D3L77pr5rUQoWgD5ROQtVIZQgJkXbo1DLlK3vj11YGw5+LnF4SYti4gZmwng==}
+  dompurify@3.2.1:
+    resolution: {integrity: sha512-NBHEsc0/kzRYQd+AY6HR6B/IgsqzBABrqJbpCDQII/OK6h7B7LXzweZTDsqSW2LkTRpoxf18YUP+YjGySk6B3w==}
 
   domutils@3.1.0:
     resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
@@ -5980,6 +5983,9 @@ snapshots:
 
   '@types/trusted-types@2.0.2': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/wrap-ansi@3.0.0': {}
 
   '@typescript-eslint/eslint-plugin@8.15.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3)':
@@ -6989,7 +6995,9 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.1.3: {}
+  dompurify@3.2.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.1.0:
     dependencies:


### PR DESCRIPTION
dompurify@3.0.0 contains the following XSS vulnerabilities:

- https://avd.aquasec.com/nvd/2024/cve-2024-45801/ (7 moderate)
- https://avd.aquasec.com/nvd/2024/cve-2024-47875/ (8 important)
- https://avd.aquasec.com/nvd/2024/cve-2024-45801/ (7 moderate)
- https://avd.aquasec.com/nvd/2024/cve-2024-47875/ (8 important)

> This issue has been addressed in versions 2.5.4 and 3.1.3 of DOMPurify. All users are advised to upgrade.

This PR upgrades to v3.2.1