### PR TITLE
chore: Adjust types to be aligned with the types of DOMPurify 3.2.1

### DIFF
--- a/packages/vue-dompurify-html/package.json
+++ b/packages/vue-dompurify-html/package.json
@@ -45,7 +45,7 @@
         "test-mutation": "stryker run"
     },
     "dependencies": {
-        "dompurify": "^3.0.0"
+        "dompurify": "^3.2.1"
     },
     "peerDependencies": {
         "vue": "^3.0.0"
@@ -54,7 +54,6 @@
         "@stryker-mutator/core": "8.6.0",
         "@stryker-mutator/typescript-checker": "8.6.0",
         "@stryker-mutator/vitest-runner": "8.6.0",
-        "@types/dompurify": "3.0.5",
         "@vitest/coverage-v8": "2.1.5",
         "@vue/test-utils": "2.4.6",
         "jsdom": "25.0.1",

--- a/packages/vue-dompurify-html/test/index.spec.ts
+++ b/packages/vue-dompurify-html/test/index.spec.ts
@@ -3,7 +3,7 @@ import { createApp } from 'vue';
 import type { DOMPurifyInstanceBuilder } from '../src';
 import VueDOMPurifyHTML from '../src';
 import { buildVueDompurifyHTMLDirective } from '../src';
-import type { DOMPurifyI } from 'dompurify';
+import type { DOMPurify } from 'dompurify';
 
 describe('VueDOMPurifyHTML Plugin Install', (): void => {
     it('can be installed', (): void => {
@@ -62,7 +62,7 @@ describe('VueDOMPurifyHTML Plugin Install', (): void => {
                 sanitize(): string {
                     return 'Test';
                 },
-            } as unknown as DOMPurifyI;
+            } as unknown as DOMPurify;
         };
         app.use(VueDOMPurifyHTML, {}, instanceBuilder);
         app.mount(el);

--- a/packages/vue-dompurify-html/test/vue-dompurify-html.spec.ts
+++ b/packages/vue-dompurify-html/test/vue-dompurify-html.spec.ts
@@ -3,15 +3,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import type { DOMPurifyInstanceBuilder } from '../src/dompurify-html';
 import { buildDirective } from '../src/dompurify-html';
-import type { DOMPurifyI } from 'dompurify';
+import type { DOMPurify } from 'dompurify';
 import { sanitize, addHook } from 'dompurify';
 
 vi.mock('dompurify', async () => {
-    const actual: DOMPurifyI = await vi.importActual('dompurify');
+    const actual: { default: DOMPurify } = await vi.importActual('dompurify');
     const spy = {
         ...actual,
-        sanitize: vi.fn(actual.sanitize),
-        addHook: vi.fn(actual.addHook),
+        sanitize: vi.fn(actual.default.sanitize),
+        addHook: vi.fn(actual.default.addHook),
     };
     return {
         ...spy,
@@ -170,7 +170,7 @@ describe('VueDOMPurifyHTML Test Suite', (): void => {
                 sanitize(): string {
                     return 'Test';
                 },
-            } as unknown as DOMPurifyI;
+            } as unknown as DOMPurify;
         };
 
         const wrapper = mount(component, {

--- a/packages/vue-dompurify-html/types/dompurify-html.d.ts
+++ b/packages/vue-dompurify-html/types/dompurify-html.d.ts
@@ -1,6 +1,6 @@
 import type { ObjectDirective } from 'vue';
-import type { DOMPurifyI, HookEvent, HookName, SanitizeAttributeHookEvent, SanitizeElementHookEvent } from 'dompurify';
-type MinimalDOMPurifyInstance = Pick<DOMPurifyI, 'sanitize' | 'addHook'>;
+import type { DOMPurify, UponSanitizeElementHookEvent, UponSanitizeAttributeHookEvent } from 'dompurify';
+type MinimalDOMPurifyInstance = Pick<DOMPurify, 'sanitize' | 'addHook'>;
 export type DOMPurifyInstanceBuilder = () => MinimalDOMPurifyInstance;
 export interface MinimalDOMPurifyConfig {
     ADD_ATTR?: string[] | undefined;
@@ -25,15 +25,20 @@ export interface MinimalDOMPurifyConfig {
         attributeNameCheck?: RegExp | ((lcName: string) => boolean) | null | undefined;
         allowCustomizedBuiltInElements?: boolean | undefined;
     };
+    SANITIZE_NAMED_PROPS?: boolean | undefined;
 }
 export interface DirectiveConfig {
     default?: MinimalDOMPurifyConfig | undefined;
     namedConfigurations?: Record<string, MinimalDOMPurifyConfig> | undefined;
     hooks?: {
-        uponSanitizeElement?: ((currentNode: Element, data: SanitizeElementHookEvent, config: MinimalDOMPurifyConfig) => void) | undefined;
-        uponSanitizeAttribute?: ((currentNode: Element, data: SanitizeAttributeHookEvent, config: MinimalDOMPurifyConfig) => void) | undefined;
+        uponSanitizeElement?: ((currentNode: Node, hookEvent: UponSanitizeElementHookEvent, config: MinimalDOMPurifyConfig) => void) | undefined;
+        uponSanitizeAttribute?: ((currentNode: Element, hookEvent: UponSanitizeAttributeHookEvent, config: MinimalDOMPurifyConfig) => void) | undefined;
     } & {
-        [H in HookName]?: ((currentNode: Element, data: HookEvent, config: MinimalDOMPurifyConfig) => void) | undefined;
+        [H in 'beforeSanitizeElements' | 'afterSanitizeElements' | 'uponSanitizeShadowNode']?: ((currentNode: Node, hookEvent: null, config: MinimalDOMPurifyConfig) => void) | undefined;
+    } & {
+        [H in 'beforeSanitizeAttributes' | 'afterSanitizeAttributes']?: ((currentNode: Element, hookEvent: null, config: MinimalDOMPurifyConfig) => void) | undefined;
+    } & {
+        [H in 'beforeSanitizeShadowDOM' | 'afterSanitizeShadowDOM']?: ((currentNode: DocumentFragment, hookEvent: null, config: MinimalDOMPurifyConfig) => void) | undefined;
     };
 }
 export declare function defaultDOMPurifyInstanceBuilder(): MinimalDOMPurifyInstance;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
   packages/vue-dompurify-html:
     dependencies:
       dompurify:
-        specifier: ^3.0.0
-        version: 3.1.3
+        specifier: ^3.2.1
+        version: 3.2.1
     devDependencies:
       '@stryker-mutator/core':
         specifier: 8.6.0
@@ -88,9 +88,6 @@ importers:
       '@stryker-mutator/vitest-runner':
         specifier: 8.6.0
         version: 8.6.0(@stryker-mutator/core@8.6.0)(vitest@2.1.5(@types/node@22.7.4)(jsdom@25.0.1)(terser@5.26.0))
-      '@types/dompurify':
-        specifier: 3.0.5
-        version: 3.0.5
       '@vitest/coverage-v8':
         specifier: 2.1.5
         version: 2.1.5(vitest@2.1.5(@types/node@22.7.4)(jsdom@25.0.1)(terser@5.26.0))
@@ -1223,9 +1220,6 @@ packages:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
 
-  '@types/dompurify@3.0.5':
-    resolution: {integrity: sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==}
-
   '@types/eslint@8.56.10':
     resolution: {integrity: sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==}
 
@@ -1253,8 +1247,8 @@ packages:
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
-  '@types/trusted-types@2.0.2':
-    resolution: {integrity: sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==}
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/wrap-ansi@3.0.0':
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
@@ -1829,7 +1823,7 @@ packages:
     engines: {node: '>= 14'}
 
   concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -2082,8 +2076,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.1.3:
-    resolution: {integrity: sha512-5sOWYSNPaxz6o2MUPvtyxTTqR4D3L77pr5rUQoWgD5ROQtVIZQgJkXbo1DLlK3vj11YGw5+LnF4SYti4gZmwng==}
+  dompurify@3.2.1:
+    resolution: {integrity: sha512-NBHEsc0/kzRYQd+AY6HR6B/IgsqzBABrqJbpCDQII/OK6h7B7LXzweZTDsqSW2LkTRpoxf18YUP+YjGySk6B3w==}
 
   domutils@3.1.0:
     resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
@@ -2108,7 +2102,7 @@ packages:
     hasBin: true
 
   ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
 
   electron-to-chromium@1.5.13:
     resolution: {integrity: sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==}
@@ -4492,7 +4486,7 @@ snapshots:
       '@babel/traverse': 7.25.3
       '@babel/types': 7.26.0
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -4885,7 +4879,7 @@ snapshots:
       '@babel/parser': 7.26.2
       '@babel/template': 7.25.0
       '@babel/types': 7.26.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -4897,7 +4891,7 @@ snapshots:
       '@babel/parser': 7.26.2
       '@babel/template': 7.25.9
       '@babel/types': 7.26.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -5786,10 +5780,6 @@ snapshots:
 
   '@trysound/sax@0.2.0': {}
 
-  '@types/dompurify@3.0.5':
-    dependencies:
-      '@types/trusted-types': 2.0.2
-
   '@types/eslint@8.56.10':
     dependencies:
       '@types/estree': 1.0.5
@@ -5819,7 +5809,8 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
-  '@types/trusted-types@2.0.2': {}
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/wrap-ansi@3.0.0': {}
 
@@ -5970,7 +5961,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
@@ -6220,6 +6211,12 @@ snapshots:
   agent-base@6.0.2:
     dependencies:
       debug: 4.3.7(supports-color@9.4.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  agent-base@7.1.0:
+    dependencies:
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -6687,6 +6684,10 @@ snapshots:
     dependencies:
       ms: 2.0.0
 
+  debug@4.3.7:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.3.7(supports-color@9.4.0):
     dependencies:
       ms: 2.1.3
@@ -6759,7 +6760,9 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.1.3: {}
+  dompurify@3.2.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.1.0:
     dependencies:
@@ -7293,8 +7296,8 @@ snapshots:
 
   http-proxy-agent@7.0.2:
     dependencies:
-      agent-base: 7.1.0(supports-color@9.4.0)
-      debug: 4.3.7(supports-color@9.4.0)
+      agent-base: 7.1.0
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -7304,6 +7307,13 @@ snapshots:
     dependencies:
       agent-base: 6.0.2
       debug: 4.3.7(supports-color@9.4.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.5:
+    dependencies:
+      agent-base: 7.1.0
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -7468,7 +7478,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -7515,7 +7525,7 @@ snapshots:
       form-data: 4.0.0
       html-encoding-sniffer: 4.0.0
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.5(supports-color@9.4.0)
+      https-proxy-agent: 7.0.5
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.12
       parse5: 7.1.2
@@ -7636,7 +7646,7 @@ snapshots:
   log4js@6.9.1:
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7
       flatted: 3.3.1
       rfdc: 1.4.1
       streamroller: 3.1.5
@@ -8642,7 +8652,7 @@ snapshots:
   streamroller@3.1.5:
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -9036,7 +9046,7 @@ snapshots:
   vite-node@2.1.5(@types/node@22.7.4)(terser@5.26.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7
       es-module-lexer: 1.5.4
       pathe: 1.1.2
       vite: 5.4.11(@types/node@22.7.4)(terser@5.26.0)
@@ -9127,7 +9137,7 @@ snapshots:
       '@vitest/spy': 2.1.5
       '@vitest/utils': 2.1.5
       chai: 5.1.2
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7
       expect-type: 1.1.0
       magic-string: 0.30.12
       pathe: 1.1.2


### PR DESCRIPTION
Minimal version of DOMPurify has been raised to 3.2.1 to avoid managing the compatibility between multiple versions.